### PR TITLE
change event shouldn't change state

### DIFF
--- a/js/jquery.screwdefaultbuttonsV2.js
+++ b/js/jquery.screwdefaultbuttonsV2.js
@@ -160,7 +160,7 @@
 			    	});
 			    }
 			    
-			    if( $.browser.version == 7.0 || $.browser.version == 8.0 ){
+			    if (!$.support.leadingWhitespace) { // IE 7 & 8, detection should be different
 			    	var $thisId = $(this).attr('id');
 			    	var $thisLabel = $('label[for="' + $thisId + '"]');
 			    	$thisLabel.on('click', function(){


### PR DESCRIPTION
Only the click event should change state, to be consistent with a regular checkbox. The click event will change the state and call the change event.
