### PR TITLE
Adds accessibility (keyboard and AT)

### DIFF
--- a/js/jquery.screwdefaultbuttonsV2.js
+++ b/js/jquery.screwdefaultbuttonsV2.js
@@ -43,7 +43,6 @@
 				var $thisParent = $this.parent('div');
 
 				var inputId = $this.attr('id');
-				console.log('inputId: ', inputId);
 				var assocLabel = inputId && $('label[for="' + inputId + '"]');
 				if (assocLabel) {
 					$thisParent.attr('title', assocLabel.text());


### PR DESCRIPTION
Allows ScrewDefaultButtons to be interacted upon by keyboard and also provides roles and attributes that allow screen readers to read everything out properly.
- input[type=radio] gets role="radio" and a title attribute of the original label (if one exists)
- input[type=checkbox] gets role="checkbox" and a title attribute of the original label (if one exists)
- both toggle aria-checked={true/false}
